### PR TITLE
Update to use strlcpy

### DIFF
--- a/googleauth.c
+++ b/googleauth.c
@@ -203,7 +203,7 @@ static const char *getURL(const char *secret, const char *label,
   
     int total_length = strlen(encoder) + strlen(encodedURL) + 1;
     *encoderURL = (char*)malloc(total_length);
-    strncpy(*encoderURL, encoder, strlen(encoder));
+    strlcpy(*encoderURL, encoder, strlen(encoder)+1);
     strlcat(*encoderURL, encodedURL, total_length);
 
     free((void *)encodedURL);
@@ -666,11 +666,12 @@ int main(int argc, char *argv[]) {
   if (!label) {
     char hostname[128] = { 0 };
     if (gethostname(hostname, sizeof(hostname)-1)) {
-      strcpy(hostname, "unix");
+		const char *default_hostname = "unix";
+		strlcpy(hostname, default_hostname, 5);
     }
     int total_length = strlen(user) + strlen(hostname) + 2;
-    label = strncpy(malloc(strlen(user) + strlen(hostname) + 2), 
-                     user, strlen(user));
+    label = malloc(total_length); 
+    strlcpy(label, user, strlen(user)+1);
     strlcat(label, "@", total_length);
     strlcat(label, hostname, total_length);
   }


### PR DESCRIPTION
OBSD has moved away from strcpy as an unsafe method of string copying.

They've implimented strlcpy instead, which from the strlcpy(3) man page
are:

"designed to be safer, more consistent, and less error prone
replacements for the easily misused functions strncpy(3) and
strncat(3)."

/usr/bin/googleauth would exhibit strange string behaviour randomly on
the old strcpy function, particularly when constructing the 'user@host'
component of the 'label' string.

On a run of 5 batch-built googleauth configs, at least onetime the
value of 'label' would contain output from a nasty memory overflow and
typically segfault the process.

The same could happen when constructing the 'encoderURL' variable.

These two cases should now be fixed.
