### PR TITLE
Stop checking for tty when printing QRcode

### DIFF
--- a/googleauth.c
+++ b/googleauth.c
@@ -233,7 +233,14 @@ static void displayQRCode(const char *secret, const char *label,
   // it at build-time, we look for it at run-time. If it cannot be found, the
   // user can still type the code in manually, or he can copy the URL into
   // his browser.
-  if (isatty(1)) {
+ 
+  //Note: testing for a TTY at execution time is a bit of a mixed bag. This prevents the qrcode 
+  //generation from executing if googleauth is invoked inside a pipeline, such as this: 
+  //	sudo googleauth -f -c -w 100 ${USERNAME} 2>&1 | tee ${GAUTH_LOG}
+  //	or
+  //	sudo googleauth -f -c -w 100 ${USERNAME} > ${GAUTH_LOG} 2>&1 
+  //The ability to log the output of this command is important and should not be hinderred. 
+  //if (isatty(1)) {
     void *qrencode = dlopen("libqrencode.so.2", RTLD_NOW | RTLD_LOCAL);
     if (!qrencode) {
       qrencode = dlopen("libqrencode.so.3", RTLD_NOW | RTLD_LOCAL);
@@ -335,7 +342,7 @@ static void displayQRCode(const char *secret, const char *label,
       }
       dlclose(qrencode);
     }
-  }
+  //} //disabled test for isatty(1)
 
   free((char *)url);
   free(encoderURL);


### PR DESCRIPTION
This change is a bit debatable, and becomes more relevant when the code for generating a qrcode to .png is added.

When running /usr/bin/googleauth in a pipeline, the test isatty(1)
actually prevents the QR code from being printed.

Now that makes a kind of sense when you want automation to just throw
away all output, but if you want to automate AND save the results to a
log then you may want to have that QR in the log.

Certainly if you run the command in a tee, it would be desirable to have
the QR printed in the console while also in the log file.

It's true that the log file gets filled with terminal control characters
that represent the QR code. But if you cat the log out the result is
something that can can be scanned by a phone again.

Now, where it becomes more relevant is when the steps to write a .png file are added to displayQRCode. I expanded on this function and got it to create the .png output for the QR code because it was already handling all the QR generation any way. I didn't see much reason to spawning a new function to go through the process of reconstructing the QRcode *qrcode structure a second time. 

But so, if the tty check is in place, then it prevented the .png file from being created completely, since it was all hooked into the displayQRCode function. 

That balanced against the desire to tee the graphic to the screen AND log output to a file, suggests it may be more useful to remove the isatty check. 
