### PR TITLE
Remove reference to Yubikey from man1

### DIFF
--- a/googleauth.1
+++ b/googleauth.1
@@ -116,7 +116,7 @@ is stored as the new last-use counter, and the login is accepted.
 .Sh FILES
 .Bl -tag -width /var/db/googleauth
 .It Pa /var/db/googleauth
-directory containing user entries for Yubikey
+directory containing user entries for Googleauth
 .El
 .Sh SEE ALSO
 .Xr login 1 ,


### PR DESCRIPTION
The man(1) file for googleauth had a reference to Yubikey left over from
when it was forked.

Changing the refernce to read 'googelauth' instead.
