### PR TITLE
HOTP configs not getting *ALLOW_REUSE config

### DIFF
--- a/googleauth.c
+++ b/googleauth.c
@@ -802,6 +802,7 @@ int main(int argc, char *argv[]) {
       addConfig(secret, sizeof(secret), buf);
     }
   } else {
+    addConfig(secret, sizeof(secret), disallow);
     if (!window_size) {
       if (maybe("By default, three tokens are valid at any one time.  "
                 "This accounts for\ngenerated-but-not-used tokens and "


### PR DESCRIPTION
When HOTP configs are generated, the previously did not get the second
value, ALLOW_REUSE or DISALLOW_REUSE, causing HOTP configs to fail
when /usr/libexec/auth/login_googleauth failed to parse the config file.

This change adds that flag backin, despite the fact that it's irrelevant
for this mode of GA.

The value is defaulted to DISALLOW_REUSE, ignoring the choices made at
/usr/bin/googleauth invocation.
