### PR TITLE
Allow Window Width of 100 (meant for HOTP)

### DIFF
--- a/googleauth.c
+++ b/googleauth.c
@@ -623,8 +623,15 @@ int main(int argc, char *argv[]) {
       char *endptr;
       errno = 0;
       long l = strtol(optarg, &endptr, 10);
-      if (errno || endptr == optarg || *endptr || l < 1 || l > 21) {
-        fprintf(stderr, "-w requires an argument in the range 1..21\n");
+	  //Originally the limit for window width was 21. For counter based
+	  //tokens this isn't a wide enough window given a widely distributed
+	  //infrastructure. Consider if you spend a month working in one 
+	  //branch of the inf, iterating your tokens counter, and then attempt
+	  //to log into a rarely-visited server. You would be locked out.
+	  //It's debatable whether 100 is actually wide //enough//, but 
+	  //it seems a fair place to start. 
+      if (errno || endptr == optarg || *endptr || l < 1 || l > 100) {
+        fprintf(stderr, "-w requires an argument in the range 1..100\n");
         _exit(1);
       }
       window_size = (int)l;


### PR DESCRIPTION
This change allows a window width of 100 rather than the original limit
of 17

The purpose here is for HOTP logins in a large infrastrucutre,

As the commit comment suggests, a mobile device counter can advance
several tens of times before a user tries to log into a rarely accessed
server.

With out this window limit expansion, after 17 connections to other
servers, the user would be locked out of the few they dont touch on a
regular basis (IE: those machiens who dont have their
/var/db/googleauth/<USERNAME>.counter advanced to match their mobile
deivce).

A better change here would be to TEST the HOTP/TOTP config that's being
built and if HOTP is selected, then the full window is allowed, else the
original 17 is allowed.

More commits to this change are called for before it's merged to master. 
