### PR TITLE
Start building qrcodes into .png files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 #	$Id: Makefile,v 1.1.1.1 2012/03/16 14:13:08 raxis Exp $
-
+#The png package is requried to compile this program
 PROG=	googleauth
 SRCS=	googleauth.c base32.c 
-CFLAGS+=-DPASSWD -Wall -std=c99 -ggdb -O0 
+CFLAGS+=-DPASSWD -Wall -std=c99 -ggdb -O0 -I/usr/local/include/libpng16 -I/usr/local/include
 	
 DPADD+= ${LIBUTIL}
-LDADD+= -lutil -lcrypto
+LDADD+= -lutil -lcrypto -L/usr/local/lib -lpng
 
 BINOWN=	root
 BINGRP=	auth


### PR DESCRIPTION
This change should not be merged into Master with out review regarding licensing

So, this is the most controversial change i've made made to googleauth. I've done my best to include the original attribution for writePNG, and left that function 100% unchanged from it's source. But still, I'm borrowing from a different project in an attempt to self-contain everything in the googleauth module. 

We obviously wouldn't receive improvements to the writePNG function as a result, which I don't think would be very dependable in an OBSD included project. 

Googleauth runs fine with out the qrencode package being installed. 

If I remove the writePNG function, it will fail at compile time unless qrencode is provided. 

Further, I've introduced a dependency I couldn't work around: libpng

For those two reasons, I'm iffy about this change being pushed to the Master branch. 

---

This change causes /usr/bin/googleauth to create a png file at
/var/db/googleauth/<USERNAME>.png for reference later.

The objective is two fold:

1) removes the need to broadcast sensitive authentication credentials to
a remove Google Server (who's EULA does not guarantee the information
wont be stored)

2) store the qr code for later reference should a user need to re-add
the token to their mobile device.

This change is a large departure from original code. It...

1) includes the function writePNG, borrowed directly from the qrencode
 project (with citation)
2) re-arranges the position of the openSecretDbFile fuction so it's
 defined before displayQRCode
3) provides the new function openSecretDbFilePath since the writePNG
 requires a char\* array for it's output file (openSecretDbFile provides
 file descriptors which writePNG cant use with out editing it)
4) changes the function displayQRCode to take in the char*
 array 'user' so the png file can be created with the users name
 outside of the Main function (where Main is responsible for creating all
 other config files)
5) Provide #define and other values needed by writePNG to generate PNG
 files.
6) Include required headerfiles png.h and qrencode.h for the data
 strucutres needed by writePNG and displayQRCode respecively
7) Update the googleauth/Makefile to include libpng at compile time
